### PR TITLE
routing authenticated users to /content

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -13,7 +13,11 @@ buckets      = require './routes/buckets'
 
 RedisStore =  require('connect-redis')(session);
 
-sessionOptions = { secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat' }
+sessionOptions = {
+    secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat',
+    resave: false,
+    saveUninitialized: false
+}
 
 if process.env.USE_REDIS_SESSION is '1'
   sessionOptions.store = new RedisStore()

--- a/routes/buckets.coffee
+++ b/routes/buckets.coffee
@@ -12,7 +12,7 @@ BUCKETS = (i.trim() for i in process.env.BUCKETS.split ',')
 
 router = express.Router()
 
-router.get '/buckets', ensureLoggedIn('/'), (req, res) ->
+router.get '/buckets', ensureLoggedIn('/index'), (req, res) ->
   if BUCKETS.length > 1
     res.render 'buckets',
       title:   'List of exposed sites'
@@ -33,9 +33,9 @@ returnFile = (bucket) -> (req, res) ->
       res.set awsRes.headers
       awsRes.pipe res
 
-router.get '/content/*', ensureLoggedIn('/'), returnFile BUCKETS[0]
+router.get '/content/*', ensureLoggedIn('/index'), returnFile BUCKETS[0]
 
-router.get '/buckets/:bucket/*', ensureLoggedIn('/'), (req, res) ->
+router.get '/buckets/:bucket/*', ensureLoggedIn('/index'), (req, res) ->
   returnFile(req.params.bucket)(req, res)
 
 module.exports = router

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -5,6 +5,8 @@ GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
 
 router = express.Router()
 
+{ensureLoggedIn}    = require 'connect-ensure-login'
+
 
 # Configure google login
 protocol = if process.env.USE_SSL is '1' then 'https' else 'http'
@@ -61,7 +63,10 @@ passport.deserializeUser (id, done) ->
     done null, USERS[id]
 
 
-router.get '/', (req, res) ->
+router.get '/', ensureLoggedIn('/index'), (req, res) ->
+  res.redirect('/buckets/')
+
+router.get '/index', (req, res) ->
   res.render 'index',
     title: 'Protected S3 bucket'
     domain: if process.env.ALLOWED_DOMAINS then process.env.ALLOWED_DOMAINS else 'any'

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -7,11 +7,11 @@ router = express.Router()
 
 
 # Configure google login
-protocol = if !!process.env.USE_SSL then 'https' else 'http'
+protocol = if process.env.USE_SSL is '1' then 'https' else 'http'
 strategy = new GoogleStrategy
     clientID:     process.env.GOOGLE_CLIENT_ID
     clientSecret: process.env.GOOGLE_CLIENT_SECRET
-    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1:3000"}/auth/google/return"
+    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1"}:#{process.env.PORT or "3000"}/auth/google/return"
     # realm:     process.env.GOOGLE_REALM      or "http://localhost:#{process.env.PORT or 3000}/"
     # returnURL: process.env.GOOGLE_RETURN_URL or "http://localhost:#{process.env.PORT or 3000}/auth/google/return"
   , (accessToken, refreshToken, profile, done) ->


### PR DESCRIPTION
The original problem was supposed to be about persisting the session as the internal documentation always seemed to require authentication. 
However, it seems that the session is persisted just fine, only route '/' always leads to '/index' requiring the user to authenticate even when authenticated.
Will welcome suggestions on making this more pretty.