### PR TITLE
saving session in Redis, redirect if already authenticated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 lib-cov
 *.seed
 *.log

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Don't forget to set environment variables:
 * `DOMAIN` to whatever domain you are on
 * `USE_SSL` to `1` unless you have a very good reason not to (credentials might leak there)
 * `ALLOWED_DOMAINS` to comma-separated list of domains you are accepting auth from
-* `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to whatever you requested from Google via [their Developer Console](https://console.developers.google.com/). When prompted, your origins are the root of your app (like `https://protected-s3.herokuapp.com/` and Authorized Redirect Uri is the former with the `/auth/google/return` suffix (i.e. https://protected-s3.herokuapp.com/auth/google/return))
+* `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to whatever you requested from Google via 
+  [their Developer Console](https://console.developers.google.com/). When prompted, your origins are the root of your 
+  app (like `https://protected-s3.herokuapp.com/` and Authorized Redirect Uri is the former with 
+  the `/auth/google/return` suffix (i.e. https://protected-s3.herokuapp.com/auth/google/return))
 * `BUCKETS`, `ACCESS_KEY` and `SECRET_KEY` to the bucket you want to expose and Amazon Web Services S3 credentials.
-* `USE_REDIS_SESSION` to `1` if you want to use Redis and have a persistent session
+* `USE_REDIS_SESSION` to `1` if you want to use Redis and have a persistent session (set `REDIS_URL` to the appropriate 
+  value)
+* `APP_PORT` if testing on localhost to whatever port you wish the app to run (don't forget to include the port in the 
+  Authorized Redirect Uri when requesting Google app credentials) 
+

--- a/app.coffee
+++ b/app.coffee
@@ -16,11 +16,15 @@ RedisStore =  require('connect-redis')(session);
 sessionOptions = {
     secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat',
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    cookie: {
+        maxAge: 2592000000          # 30 days
+        name: 'protected-s3.sid',
+    }
 }
 
 if process.env.USE_REDIS_SESSION is '1'
-    redisURL = require('redis-url').connect(process.env.REDISCLOUD_URL)
+    redisURL = require('redis-url').connect(process.env.REDIS_URL)
     options =
         host: redisURL.hostname
         port: redisURL.port

--- a/app.coffee
+++ b/app.coffee
@@ -8,27 +8,37 @@ bodyParser   = require 'body-parser'
 passport     = require 'passport'
 
 
-RedisStore =  require('connect-redis')(session);
+use_secure_settings = process.env.USE_SSL is '1'
+sessionOptions =
+    secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat'
+    resave: false
+    saveUninitialized: false
+    name: 'protected_s3.sid'
+    proxy: use_secure_settings
+    cookie:
+        maxAge: 30 * 24 * 60 * 60 * 1000          # 30 days
+        secure: use_secure_settings
+        domain: process.env.DOMAIN
 
-sessionOptions = {
-    secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat',
-    resave: false,
-    saveUninitialized: false,
-    name: 'protected-s3.sid',
-    cookie: {
-        maxAge: 2592000000          # 30 days
-    }
-}
-
-if process.env.USE_REDIS_SESSION is '1'
-    redisURL = require('redis-url').connect(process.env.REDIS_URL)
-    options =
-        host: redisURL.hostname
-        port: redisURL.port
-        pass: redisURL.password
+if process.env.USE_REDIS_SESSION is '1' and process.env.REDIS_URL
+    redisClient = require('redis-url').connect(process.env.REDIS_URL)
+    redisClient.on 'error', (err) ->
+        console.log "REDIS -> emit: ERROR", err
+    options = client: redisClient
+    RedisStore =  require('connect-redis')(session);
     sessionOptions.store = new RedisStore(options)
 
+    process.on 'SIGTERM', ->
+        redisClient.quit()
+        redisClient.unref()
+        redisClient = null
+        return
+
+
 app = express()
+
+if use_secure_settings
+  app.set('trust proxy', 1)
 
 app.set('views', path.join(__dirname, 'views'))
 app.set('view engine', 'jade')
@@ -74,6 +84,5 @@ app.use (err, req, res, next) ->
 
 if not process.env.BUCKETS
     console.error "Please set BUCKETS environment variable, otherwise this app has no sense."
-
 
 module.exports = app

--- a/app.coffee
+++ b/app.coffee
@@ -18,7 +18,7 @@ sessionOptions =
     cookie:
         maxAge: 30 * 24 * 60 * 60 * 1000          # 30 days
         secure: use_secure_settings
-        domain: process.env.DOMAIN
+        domain: if process.env.DOMAIN == 'localhost' then null else process.env.DOMAIN
 
 if process.env.USE_REDIS_SESSION is '1' and process.env.REDIS_URL
     redisClient = require('redis-url').connect(process.env.REDIS_URL)

--- a/app.coffee
+++ b/app.coffee
@@ -17,9 +17,9 @@ sessionOptions = {
     secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat',
     resave: false,
     saveUninitialized: false,
+    name: 'protected-s3.sid',
     cookie: {
         maxAge: 2592000000          # 30 days
-        name: 'protected-s3.sid',
     }
 }
 

--- a/app.coffee
+++ b/app.coffee
@@ -5,11 +5,8 @@ favicon      = require 'static-favicon'
 logger       = require 'morgan'
 cookieParser = require 'cookie-parser'
 bodyParser   = require 'body-parser'
-
 passport     = require 'passport'
 
-routes       = require './routes/index'
-buckets      = require './routes/buckets'
 
 RedisStore =  require('connect-redis')(session);
 
@@ -37,15 +34,19 @@ app.set('views', path.join(__dirname, 'views'))
 app.set('view engine', 'jade')
 
 app.use(favicon())
+app.use(require('stylus').middleware(path.join(__dirname, 'public')))
+app.use(express.static(path.join(__dirname, 'public')))
 app.use(logger('dev'))
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded())
 app.use(cookieParser())
-app.use(require('stylus').middleware(path.join(__dirname, 'public')))
-app.use(express.static(path.join(__dirname, 'public')))
 app.use(session(sessionOptions))
 app.use(passport.initialize())
 app.use(passport.session())
+
+routes       = require './routes/index'
+buckets      = require './routes/buckets'
+
 app.use('/', routes)
 app.use('/', buckets)
 

--- a/app.coffee
+++ b/app.coffee
@@ -20,7 +20,12 @@ sessionOptions = {
 }
 
 if process.env.USE_REDIS_SESSION is '1'
-  sessionOptions.store = new RedisStore()
+    redisURL = require('redis-url').connect(process.env.REDISCLOUD_URL)
+    options =
+        host: redisURL.hostname
+        port: redisURL.port
+        pass: redisURL.password
+    sessionOptions.store = new RedisStore(options)
 
 app = express()
 

--- a/app.coffee
+++ b/app.coffee
@@ -13,7 +13,11 @@ buckets      = require './routes/buckets'
 
 RedisStore =  require('connect-redis')(session);
 
-sessionOptions = { secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat' }
+sessionOptions = {
+    secret: process.env.EXPRESS_SESSION_SECRET or 'keyboard cat',
+    resave: false,
+    saveUninitialized: false
+}
 
 if process.env.USE_REDIS_SESSION is '1'
   sessionOptions.store = new RedisStore()

--- a/bin/www
+++ b/bin/www
@@ -4,5 +4,23 @@ app = require('../app.coffee')
 
 app.set('port', process.env.PORT || 3000)
 
+shutdownInProgress = false
+onSigTerm = ->
+  if shutdownInProgress
+    return
+  console.log 'Graceful shutdown ...'
+  shutdownInProgress = true
+  server?.close? ->
+    setTimeout ->
+      process.exit(0)
+      return
+    , 500
+    return
+  return
+
+
+# graceful shutdown
+process.on 'SIGTERM', onSigTerm
+
 server = app.listen app.get('port'), ->
   debug 'Express server listening on port ' + server.address().port

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "passport": "~0.2.0",
     "passport-google": "~0.3.0",
     "passport-google-oauth": "~0.1.5",
+    "redis-url": "^1.2.0",
     "static-favicon": "~1.0.0",
     "stylus": "0.42.3"
   },

--- a/routes/buckets.coffee
+++ b/routes/buckets.coffee
@@ -12,7 +12,7 @@ BUCKETS = (i.trim() for i in process.env.BUCKETS.split ',')
 
 router = express.Router()
 
-router.get '/buckets', ensureLoggedIn('/'), (req, res) ->
+router.get '/buckets', ensureLoggedIn('/index'), (req, res) ->
   if BUCKETS.length > 1
     res.render 'buckets',
       title:   'List of exposed sites'
@@ -33,9 +33,9 @@ returnFile = (bucket) -> (req, res) ->
       res.set awsRes.headers
       awsRes.pipe res
 
-router.get '/content/*', ensureLoggedIn('/'), returnFile BUCKETS[0]
+router.get '/content/*', ensureLoggedIn('/index'), returnFile BUCKETS[0]
 
-router.get '/buckets/:bucket/*', ensureLoggedIn('/'), (req, res) ->
+router.get '/buckets/:bucket/*', ensureLoggedIn('/index'), (req, res) ->
   returnFile(req.params.bucket)(req, res)
 
 module.exports = router

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -5,6 +5,8 @@ GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
 
 router = express.Router()
 
+{ensureLoggedIn}    = require 'connect-ensure-login'
+
 
 # Configure google login
 protocol = if process.env.USE_SSL is '1' then 'https' else 'http'
@@ -61,7 +63,10 @@ passport.deserializeUser (id, done) ->
     done null, USERS[id]
 
 
-router.get '/', (req, res) ->
+router.get '/', ensureLoggedIn('/index'), (req, res) ->
+  res.redirect('/buckets/')
+
+router.get '/index', (req, res) ->
   res.render 'index',
     title: 'Protected S3 bucket'
     domain: if process.env.ALLOWED_DOMAINS then process.env.ALLOWED_DOMAINS else 'any'

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -7,11 +7,11 @@ router = express.Router()
 
 
 # Configure google login
-protocol = if !!process.env.USE_SSL then 'https' else 'http'
+protocol = if process.env.USE_SSL is '1' then 'https' else 'http'
 strategy = new GoogleStrategy
     clientID:     process.env.GOOGLE_CLIENT_ID
     clientSecret: process.env.GOOGLE_CLIENT_SECRET
-    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1:3000"}/auth/google/return"
+    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1"}:#{process.env.PORT or "3000"}/auth/google/return"
     # realm:     process.env.GOOGLE_REALM      or "http://localhost:#{process.env.PORT or 3000}/"
     # returnURL: process.env.GOOGLE_RETURN_URL or "http://localhost:#{process.env.PORT or 3000}/auth/google/return"
   , (accessToken, refreshToken, profile, done) ->

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -47,6 +47,9 @@ strategy = new GoogleStrategy
 
     if !use_redis_store
       USERS[user.id] = user if user
+      console.log 'Authenticated - saving to MemStore.', user
+    else
+      console.log 'Authenticated - saving to RedisStore.', user
 
     done null, user
 

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -10,10 +10,11 @@ router = express.Router()
 
 # Configure google login
 protocol = if process.env.USE_SSL is '1' then 'https' else 'http'
+port = if process.env.APP_PORT then ":" + process.env.APP_PORT else ""
 strategy = new GoogleStrategy
     clientID:     process.env.GOOGLE_CLIENT_ID
     clientSecret: process.env.GOOGLE_CLIENT_SECRET
-    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1"}:#{process.env.PORT or "3000"}/auth/google/return"
+    callbackURL: "#{protocol}://#{process.env.DOMAIN or "127.0.0.1"}#{port}/auth/google/return"
     # realm:     process.env.GOOGLE_REALM      or "http://localhost:#{process.env.PORT or 3000}/"
     # returnURL: process.env.GOOGLE_RETURN_URL or "http://localhost:#{process.env.PORT or 3000}/auth/google/return"
   , (accessToken, refreshToken, profile, done) ->


### PR DESCRIPTION
* fixed saving sessions in RedisStore when app is deployed remotely (localhost worked fine)
* added redirect to '/buckets' if user is already authenticated
* added hostedDomain param to google auth request - only accounts from the ALLOWED_DOMAINS will be available to select when authenticating via google

now deployed at https://apiary-internal-docs-staging.herokuapp.com